### PR TITLE
Refine template formatting for readability

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,16 +3,63 @@
 <head>
 <meta charset="UTF-8" />
 <title>排放预测与优化 Dashboard</title>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-css-reset@1.4.0/dist/reset.min.css" />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/modern-css-reset@1.4.0/dist/reset.min.css"
+/>
 <style>
-  body { font-family: Arial, sans-serif; margin: 40px; background: #f5f7fa; color: #333; }
-  .container { max-width: 800px; margin: auto; background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1); }
-  h1 { text-align: center; margin-bottom: 20px; }
-  form { display: flex; gap: 10px; margin-bottom: 20px; flex-wrap: wrap; }
-  input { flex: 1 1 30%; padding: 10px; border: 1px solid #ccc; border-radius: 4px; }
-  button { padding: 10px 20px; border: none; background: #4caf50; color: #fff; border-radius: 4px; cursor: pointer; }
-  button:hover { background: #45a049; }
-  #result { font-size: 1.2em; margin-top: 20px; }
+  body {
+    font-family: Arial, sans-serif;
+    margin: 40px;
+    background: #f5f7fa;
+    color: #333;
+  }
+
+  .container {
+    max-width: 800px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  h1 {
+    text-align: center;
+    margin-bottom: 20px;
+  }
+
+  form {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+  }
+
+  input {
+    flex: 1 1 30%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+
+  button {
+    padding: 10px 20px;
+    border: none;
+    background: #4caf50;
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  button:hover {
+    background: #45a049;
+  }
+
+  #result {
+    font-size: 1.2em;
+    margin-top: 20px;
+  }
 </style>
 </head>
 <body>
@@ -27,22 +74,34 @@
   <div id="result"></div>
 </div>
 <script>
-  document.getElementById('predict-form').addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const payload = [{
-      electricity: Number(document.getElementById('electricity').value),
-      gdp: Number(document.getElementById('gdp').value),
-      coal: Number(document.getElementById('coal').value),
-    }];
-    const res = await fetch('/predict', {
+  const form = document.getElementById('predict-form');
+  const resultElement = document.getElementById('result');
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const payload = [
+      {
+        electricity: Number(document.getElementById('electricity').value),
+        gdp: Number(document.getElementById('gdp').value),
+        coal: Number(document.getElementById('coal').value),
+      },
+    ];
+
+    const response = await fetch('/predict', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
-    const data = await res.json();
-    document.getElementById('result').textContent = data.prediction
-      ? `预测排放: ${data.prediction[0].toFixed(2)}`
-      : `错误: ${data.error}`;
+
+    const data = await response.json();
+
+    if (data.prediction) {
+      resultElement.textContent = `预测排放: ${data.prediction[0].toFixed(2)}`;
+      return;
+    }
+
+    resultElement.textContent = `错误: ${data.error}`;
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Reformat the dashboard template to wrap long stylesheet properties across multiple lines
- Adjust the JavaScript submit handler to use helper variables and stay within the 88-character limit

## Testing
- `black templates/index.html` *(fails: cannot parse HTML content)*

------
https://chatgpt.com/codex/tasks/task_e_68c945d7fc80832899c71eee6620e870